### PR TITLE
Chore/add pr labeling

### DIFF
--- a/.github/.github/pr-labeler.yml
+++ b/.github/.github/pr-labeler.yml
@@ -1,0 +1,5 @@
+feature: ['feature/*', 'feat/*']
+enhancement: enhancement/*
+fix: fix/*
+chore: chore/*
+bug: bug/*

--- a/.github/workflows/typescript.build.yml
+++ b/.github/workflows/typescript.build.yml
@@ -29,6 +29,16 @@ env:
   PACKR_REVISION: 
 
 jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: TimonVS/pr-labeler-action@v3
+        with:
+          configuration-path: .github/pr-labeler.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   yarn:
     name: Build/Lint/Test/Packr
     runs-on: ubuntu-latest

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -9,7 +9,6 @@ on:
     secrets:
       NODE_AUTH_TOKEN:
         required: true
-  pull_request:
   push:
     branches: [ $default-branch ]
 

--- a/.github/workflows/typescript.sonarcloud.yml
+++ b/.github/workflows/typescript.sonarcloud.yml
@@ -23,7 +23,11 @@ jobs:
     name: Sonarcloud Analysis
     runs-on: ubuntu-latest
     steps:
-        
+
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - name: Retrieve coverage artifacts
       uses: actions/download-artifact@v3
       with:

--- a/README.md
+++ b/README.md
@@ -57,9 +57,8 @@ Pushes coverage to [sonarcloud](https://sonarcloud.io/)
     needs: build
     uses: flexbase-eng/.github/.github/workflows/typescript.sonarcloud.yml@main
     with:
-      project_key: flexbase-eng_http-client-middleware
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      project_key: flexbase-eng_<repo-name>
+    secrets: inherit
 ```
 
 #### Inputs


### PR DESCRIPTION
- when utilizing the standard flexbase build workflow, add relevant labels to the PR for automated release management workflows.
process:
1. branch names will trigger a label 
2. labels are grouped automatically for release management in github in "draft" format

Also added a checkout step for sonarcloud, otherwise it will scan an empty directory.  Saw failures in a different repo related to not being able to detect SCM provider, which implied that the .github folder was not checked out and code downloaded for scanning
