### PR TITLE
Chore add publish npm

### DIFF
--- a/.github/workflows/typescript.build.yml
+++ b/.github/workflows/typescript.build.yml
@@ -55,42 +55,45 @@ jobs:
     - name: Build revision env
       if: ${{ inputs.revision != ''}}
       run: echo 'PACKR_REVISION=--revision ${{ inputs.revision }}' >> $GITHUB_ENV
-
-  setup:
-    name: Setup
-    runs-on: ubuntu-latest
-    steps:
-    - name: Create cli install command yarn
-      if: inputs.package_manager == 'yarn'
-      run: echo "CLI_INSTALL=yarn install --frozen-lockfile" >> $GITHUB_ENV
-    - name: Create cli install command npm
-      if: inputs.package_manager == 'npm'
-      run: echo "CLI_INSTALL=npm run --ci" >> $GITHUB_ENV
-    - name: Create cli build command yarn
-      if: inputs.package_manager == 'yarn'
-      run: echo "CLI_BUILD=yarn build" >> $GITHUB_ENV
-    - name: Create cli build command npm
-      if: inputs.package_manager == 'npm'
-      run: echo "CLI_BUILD=npm run build" >> $GITHUB_ENV
-    - name: Create cli lint command yarn
-      if: inputs.package_manager == 'yarn'
-      run: echo "CLI_LINT=yarn lint" >> $GITHUB_ENV
-    - name: Create cli lint command npm
-      if: inputs.package_manager == 'npm'
-      run: echo "CLI_LINT=npm run lint" >> $GITHUB_ENV
-    
+  
   build-lint-test:
     name: Build/Lint/Test/Packr
-    needs: [packr-versions, setup]
+    needs: [packr-versions]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0 
+    
     - uses: actions/setup-node@v3
       with:
         node-version: latest
         cache: ${{ inputs.package_manager }}
+
+    - name: Create cli install command yarn
+      if: inputs.package_manager == 'yarn'
+      run: echo "CLI_INSTALL=yarn install --frozen-lockfile" >> $GITHUB_ENV
+    
+    - name: Create cli install command npm
+      if: inputs.package_manager == 'npm'
+      run: echo "CLI_INSTALL=npm run --ci" >> $GITHUB_ENV
+    
+    - name: Create cli build command yarn
+      if: inputs.package_manager == 'yarn'
+      run: echo "CLI_BUILD=yarn build" >> $GITHUB_ENV
+    
+    - name: Create cli build command npm
+      if: inputs.package_manager == 'npm'
+      run: echo "CLI_BUILD=npm run build" >> $GITHUB_ENV
+    
+    - name: Create cli lint command yarn
+      if: inputs.package_manager == 'yarn'
+      run: echo "CLI_LINT=yarn lint" >> $GITHUB_ENV
+      
+    - name: Create cli lint command npm
+      if: inputs.package_manager == 'npm'
+      run: echo "CLI_LINT=npm run lint" >> $GITHUB_ENV
+
     - name: Install dependencies
       run: ${{ env.CLI_INSTALL }}
 

--- a/.github/workflows/typescript.build.yml
+++ b/.github/workflows/typescript.build.yml
@@ -110,11 +110,7 @@ jobs:
       if: ${{ inputs.use_packr == true }}
       run: yarn packr ${{ env.PACKR_MAJOR_VERSION }} ${{ env.PACKR_MINOR_VERSION }} ${{ env.PACKR_REVISION }}
 
-  artifacts:
-    name: Store artifacts   
-    runs-on: ubuntu-latest
-    needs: [build-lint-test]
-    steps:
+      # note - this uploads the build as dist, please note to download it will be called dist for deploy contexts
     - name: Store build artifacts
       if: ${{ inputs.package_folder != ''}}
       uses: actions/upload-artifact@v3

--- a/.github/workflows/typescript.build.yml
+++ b/.github/workflows/typescript.build.yml
@@ -18,6 +18,10 @@ on:
       revision:
         required: false
         type: string
+      package_manager:
+        required: false
+        type: string
+        default: 'yarn'
 
 env:
   PACKR_MAJOR_VERSION: 
@@ -36,32 +40,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  build-lint-test-packr:
-    name: Build/Lint/Test/Packr
+  packr-versions:
+    name: Packr version modifier
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0 # Disabling shallow clone is recommended for improving relevancy of reporting
-    
-    - name: "Check file existence for yarn"
-      id: check_files
-      uses: andstor/file-existence-action@v1
-      with:
-        files: "yarn.lock"
-      
-    - uses: actions/setup-node@v3
-      if: steps.check_files.outputs.files_exists == 'true'
-      with:
-        node-version: latest
-        cache: 'yarn'
-
-    - uses: actions/setup-node@v3
-      if: steps.check_files.outputs.files_exists == 'false'
-      with:
-        node-version: latest
-        cache: 'npm'
-
     - name: Build major version env
       if: ${{ inputs.major_version != ''}}
       run: echo 'PACKR_MAJOR_VERSION=--major ${{ inputs.major_version }}' >> $GITHUB_ENV
@@ -74,42 +56,71 @@ jobs:
       if: ${{ inputs.revision != ''}}
       run: echo 'PACKR_REVISION=--revision ${{ inputs.revision }}' >> $GITHUB_ENV
 
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # Disabling shallow clone is recommended for improving relevancy of reporting
+    - uses: actions/setup-node@v3
+      with:
+        node-version: latest
+        cache: ${{ inputs.package_manager }}
+
+  yarn:
+    if: inputs.package_manager == 'yarn'
+    name: Build/Lint/Test/Packr
+    needs: [packr-versions, setup]
+    runs-on: ubuntu-latest
+    steps:
     - name: Install yarn
-      if: steps.check_files.outputs.files_exists == 'true'
       run: yarn install --frozen-lockfile
 
     - name: Build yarn
-      if: steps.check_files.outputs.files_exists == 'true'
       run: yarn build
 
     - name: Lint yarn
-      if: steps.check_files.outputs.files_exists == 'true'
       run: yarn lint
 
     - name: Test yarn
-      if: steps.check_files.outputs.files_exists == 'true'
       run: yarn test   
-
-    - name: Install npm
-      if: steps.check_files.outputs.files_exists == 'false'
-      run: npm install --ci
-
-    - name: Build npm
-      if: steps.check_files.outputs.files_exists == 'false'
-      run: npm run build
-
-    - name: Lint npm
-      if: steps.check_files.outputs.files_exists == 'false'
-      run: npm run lint
-
-    - name: Test npm
-      if: steps.check_files.outputs.files_exists == 'false'
-      run: npm run test    
 
     - name: Packr
       if: ${{ inputs.use_packr == true }}
       run: yarn packr ${{ env.PACKR_MAJOR_VERSION }} ${{ env.PACKR_MINOR_VERSION }} ${{ env.PACKR_REVISION }}
 
+  npm:
+    if: inputs.package_manager == 'npm'
+    name: Build/Lint/Test/Packr
+    needs: [packr-versions, setup]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install npm
+      run: npm install --ci
+
+    - name: Build npm
+      run: npm run build
+
+    - name: Lint npm
+      run: npm run lint
+
+    - name: Test npm
+      run: npm run test    
+
+    - name: Packr
+      if: ${{ inputs.use_packr == true }}
+      run: npm run packr ${{ env.PACKR_MAJOR_VERSION }} ${{ env.PACKR_MINOR_VERSION }} ${{ env.PACKR_REVISION }}
+
+  artifacts:
+    name: Store artifacts   
+    runs-on: ubuntu-latest
+    needs: [yarn, npm]
+    if: |
+      always() &&
+      (needs.yarn.result == 'success' || needs.yarn.result == 'skipped') &&
+      (needs.npm.result == 'success' || needs.npm.result == 'skipped')
+    steps:
     - name: Store build artifacts
       if: ${{ inputs.package_folder != ''}}
       uses: actions/upload-artifact@v3

--- a/.github/workflows/typescript.build.yml
+++ b/.github/workflows/typescript.build.yml
@@ -35,8 +35,8 @@ jobs:
           configuration-path: .github/pr-labeler.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
-  yarn:
+
+  build-lint-test-packr:
     name: Build/Lint/Test/Packr
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/typescript.build.yml
+++ b/.github/workflows/typescript.build.yml
@@ -96,15 +96,15 @@ jobs:
 
     - name: Build npm
       if: steps.check_files.outputs.files_exists == 'false'
-      run: npm build
+      run: npm run build
 
     - name: Lint npm
       if: steps.check_files.outputs.files_exists == 'false'
-      run: npm lint
+      run: npm run lint
 
     - name: Test npm
       if: steps.check_files.outputs.files_exists == 'false'
-      run: npm test    
+      run: npm run test    
 
     - name: Packr
       if: ${{ inputs.use_packr == true }}

--- a/.github/workflows/typescript.build.yml
+++ b/.github/workflows/typescript.build.yml
@@ -56,7 +56,7 @@ jobs:
         node-version: latest
         cache: 'yarn'
 
-     - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v3
       if: steps.check_files.outputs.files_exists == 'false'
       with:
         node-version: latest

--- a/.github/workflows/typescript.build.yml
+++ b/.github/workflows/typescript.build.yml
@@ -45,6 +45,7 @@ jobs:
         fetch-depth: 0 # Disabling shallow clone is recommended for improving relevancy of reporting
     
     - name: "Check file existence for yarn"
+      id: check_files
       uses: andstor/file-existence-action@v1
       with:
         files: "yarn-lock.json"

--- a/.github/workflows/typescript.build.yml
+++ b/.github/workflows/typescript.build.yml
@@ -62,22 +62,22 @@ jobs:
     steps:
     - name: Create cli install command yarn
       if: inputs.package_manager == 'yarn'
-      run: echo "CLI_INSTALL: yarn install --frozen-lockfile" >> $GITHUB_ENV
+      run: echo "CLI_INSTALL=yarn install --frozen-lockfile" >> $GITHUB_ENV
     - name: Create cli install command npm
       if: inputs.package_manager == 'npm'
-      run: echo "CLI_INSTALL: npm run --ci" >> $GITHUB_ENV
+      run: echo "CLI_INSTALL=npm run --ci" >> $GITHUB_ENV
     - name: Create cli build command yarn
       if: inputs.package_manager == 'yarn'
-      run: echo "CLI_BUILD: yarn build" >> $GITHUB_ENV
+      run: echo "CLI_BUILD=yarn build" >> $GITHUB_ENV
     - name: Create cli build command npm
       if: inputs.package_manager == 'npm'
-      run: echo "CLI_BUILD: npm run build" >> $GITHUB_ENV
+      run: echo "CLI_BUILD=npm run build" >> $GITHUB_ENV
     - name: Create cli lint command yarn
       if: inputs.package_manager == 'yarn'
-      run: echo "CLI_LINT: yarn lint" >> $GITHUB_ENV
+      run: echo "CLI_LINT=yarn lint" >> $GITHUB_ENV
     - name: Create cli lint command npm
       if: inputs.package_manager == 'npm'
-      run: echo "CLI_LINT: npm run lint" >> $GITHUB_ENV
+      run: echo "CLI_LINT=npm run lint" >> $GITHUB_ENV
     
   build-lint-test:
     name: Build/Lint/Test/Packr

--- a/.github/workflows/typescript.build.yml
+++ b/.github/workflows/typescript.build.yml
@@ -76,7 +76,7 @@ jobs:
     
     - name: Create cli install command npm
       if: inputs.package_manager == 'npm'
-      run: echo "CLI_INSTALL=npm run --ci" >> $GITHUB_ENV
+      run: echo "CLI_INSTALL=npm ci" >> $GITHUB_ENV
     
     - name: Create cli build command yarn
       if: inputs.package_manager == 'yarn'

--- a/.github/workflows/typescript.build.yml
+++ b/.github/workflows/typescript.build.yml
@@ -48,7 +48,7 @@ jobs:
       id: check_files
       uses: andstor/file-existence-action@v1
       with:
-        files: "yarn-lock.json"
+        files: "yarn.lock"
       
     - uses: actions/setup-node@v3
       if: steps.check_files.outputs.files_exists == 'true'

--- a/.github/workflows/typescript.build.yml
+++ b/.github/workflows/typescript.build.yml
@@ -35,6 +35,7 @@ jobs:
           configuration-path: .github/pr-labeler.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
   yarn:
     name: Build/Lint/Test/Packr
     runs-on: ubuntu-latest
@@ -42,10 +43,23 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0 # Disabling shallow clone is recommended for improving relevancy of reporting
+    
+    - name: "Check file existence for yarn"
+      uses: andstor/file-existence-action@v1
+      with:
+        files: "yarn-lock.json"
+      
     - uses: actions/setup-node@v3
+      if: steps.check_files.outputs.files_exists == 'true'
       with:
         node-version: latest
         cache: 'yarn'
+
+     - uses: actions/setup-node@v3
+      if: steps.check_files.outputs.files_exists == 'false'
+      with:
+        node-version: latest
+        cache: 'npm'
 
     - name: Build major version env
       if: ${{ inputs.major_version != ''}}
@@ -59,17 +73,37 @@ jobs:
       if: ${{ inputs.revision != ''}}
       run: echo 'PACKR_REVISION=--revision ${{ inputs.revision }}' >> $GITHUB_ENV
 
-    - name: Install
+    - name: Install yarn
+      if: steps.check_files.outputs.files_exists == 'true'
       run: yarn install --frozen-lockfile
 
-    - name: Build
+    - name: Build yarn
+      if: steps.check_files.outputs.files_exists == 'true'
       run: yarn build
 
-    - name: Lint
+    - name: Lint yarn
+      if: steps.check_files.outputs.files_exists == 'true'
       run: yarn lint
 
-    - name: Test
-      run: yarn test    
+    - name: Test yarn
+      if: steps.check_files.outputs.files_exists == 'true'
+      run: yarn test   
+
+    - name: Install npm
+      if: steps.check_files.outputs.files_exists == 'false'
+      run: npm install --ci
+
+    - name: Build npm
+      if: steps.check_files.outputs.files_exists == 'false'
+      run: npm build
+
+    - name: Lint npm
+      if: steps.check_files.outputs.files_exists == 'false'
+      run: npm lint
+
+    - name: Test npm
+      if: steps.check_files.outputs.files_exists == 'false'
+      run: npm test    
 
     - name: Packr
       if: ${{ inputs.use_packr == true }}

--- a/.github/workflows/typescript.build.yml
+++ b/.github/workflows/typescript.build.yml
@@ -60,66 +60,57 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0 # Disabling shallow clone is recommended for improving relevancy of reporting
-    - uses: actions/setup-node@v3
-      with:
-        node-version: latest
-        cache: ${{ inputs.package_manager }}
-
-  yarn:
-    if: inputs.package_manager == 'yarn'
+    - name: Create cli install command yarn
+      if: inputs.package_manager == 'yarn'
+      run: echo "CLI_INSTALL: yarn install --frozen-lockfile" >> $GITHUB_ENV
+    - name: Create cli install command npm
+      if: inputs.package_manager == 'npm'
+      run: echo "CLI_INSTALL: npm run --ci" >> $GITHUB_ENV
+    - name: Create cli build command yarn
+      if: inputs.package_manager == 'yarn'
+      run: echo "CLI_BUILD: yarn build" >> $GITHUB_ENV
+    - name: Create cli build command npm
+      if: inputs.package_manager == 'npm'
+      run: echo "CLI_BUILD: npm run build" >> $GITHUB_ENV
+    - name: Create cli lint command yarn
+      if: inputs.package_manager == 'yarn'
+      run: echo "CLI_LINT: yarn lint" >> $GITHUB_ENV
+    - name: Create cli lint command npm
+      if: inputs.package_manager == 'npm'
+      run: echo "CLI_LINT: npm run lint" >> $GITHUB_ENV
+    
+  build-lint-test:
     name: Build/Lint/Test/Packr
     needs: [packr-versions, setup]
     runs-on: ubuntu-latest
     steps:
-    - name: Install yarn
-      run: yarn install --frozen-lockfile
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 
+    - uses: actions/setup-node@v3
+      with:
+        node-version: latest
+        cache: ${{ inputs.package_manager }}
+    - name: Install dependencies
+      run: ${{ env.CLI_INSTALL }}
 
-    - name: Build yarn
-      run: yarn build
+    - name: Build app
+      run: ${{ env.CLI_BUILD }}
 
-    - name: Lint yarn
-      run: yarn lint
+    - name: Lint app
+      run: ${{ env.CLI_LINT }}
 
     - name: Test yarn
-      run: yarn test   
+      run: ${{ inputs.package_manager }} test
 
     - name: Packr
       if: ${{ inputs.use_packr == true }}
       run: yarn packr ${{ env.PACKR_MAJOR_VERSION }} ${{ env.PACKR_MINOR_VERSION }} ${{ env.PACKR_REVISION }}
 
-  npm:
-    if: inputs.package_manager == 'npm'
-    name: Build/Lint/Test/Packr
-    needs: [packr-versions, setup]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Install npm
-      run: npm install --ci
-
-    - name: Build npm
-      run: npm run build
-
-    - name: Lint npm
-      run: npm run lint
-
-    - name: Test npm
-      run: npm run test    
-
-    - name: Packr
-      if: ${{ inputs.use_packr == true }}
-      run: npm run packr ${{ env.PACKR_MAJOR_VERSION }} ${{ env.PACKR_MINOR_VERSION }} ${{ env.PACKR_REVISION }}
-
   artifacts:
     name: Store artifacts   
     runs-on: ubuntu-latest
-    needs: [yarn, npm]
-    if: |
-      always() &&
-      (needs.yarn.result == 'success' || needs.yarn.result == 'skipped') &&
-      (needs.npm.result == 'success' || needs.npm.result == 'skipped')
+    needs: [build-lint-test]
     steps:
     - name: Store build artifacts
       if: ${{ inputs.package_folder != ''}}

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: beta - version value from package.json
         if: inputs.tag == 'beta'
-        run: npm i -g json 
+        run: npm i -g json && json -f package.json
         
       - name: beta - version value from package.json
         if: inputs.tag == 'beta'

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -45,15 +45,7 @@ jobs:
 
       - name: beta - version value from package.json
         if: inputs.tag == 'beta'
-        run: npm i -g json
-      
-      - name: set package version
-        if: inputs.tag == 'beta'
-        run: echo "PACKAGE_VERSION=${{json -f package.json | json version}}" >> $GITHUB_ENV
-
-      - name: run package.json update for beta
-        if: inputs.tag == 'beta'
-        run: json -I -f package.json -e "this.version=\"{{env.PACKAGE_VERSION}}-beta.${{github.event.number}}}\""
+        run: npm i -g json && echo "PACKAGE_VERSION=${{npx json -f package.json | json version}}" >> $GITHUB_ENV
 
       - name: Setup yarn
         if: inputs.package_manager == 'yarn'

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -46,6 +46,9 @@ jobs:
       - name: beta - version value from package.json
         if: inputs.tag == 'beta'
         run: npm i -g json
+      
+      - name: set package version
+        run: echo "PACKAGE_VERSION=${{json -f package.json | json version}}" >> $GITHUB_ENV
 
       - name: Setup yarn
         if: inputs.package_manager == 'yarn'

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -42,19 +42,13 @@ jobs:
           always-auth: true
           node-version: latest
           cache: {{ inputs.package_manager }}
-      
-      - name: install json if beta
+            
+      - name: beta - version value from package.json
         if: inputs.tag == 'beta'
-        run: npm i -g -y json
-      
-      - name: version value from package.json
-        if: inputs.tag == 'beta'
-        run: echo "PACKAGE_VERSION=${{json -f package.json | json version}}" >> $GITHUB_ENV
-
-      - name: beta - update package.json
-        if: inputs.tag == 'beta'
-        run: json -I -f package.json -e "this.version=\"{{env.}}-beta.${{github.event.number}}}\""
-        #run: echo "`jq '.version="${{env.VERSION}}-beta.${{github.event.number}}"' package.json`" > package.json
+        run: |
+          npm i -g -y json
+          echo "PACKAGE_VERSION=${{json -f package.json | json version}}" >> $GITHUB_ENV
+          json -I -f package.json -e "this.version=\"{{env.}}-beta.${{github.event.number}}}\""
 
       - name: Setup yarn
         if: inputs.package_manager == 'yarn'

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -47,10 +47,10 @@ jobs:
         if: inputs.tag == 'beta'
         run: |
           npm i -g json
-          echo "PACKAGE_VERSION=${{json -f package.json | json version}}" >> $GITHUB_ENV
+          echo PACKAGE_VERSION=${{json -f package.json | json version}} >> $GITHUB_ENV
           json -I -f package.json -e "this.version=\"{{env.}}-beta.${{github.event.number}}}\""
         shell: run
-        
+
       - name: Setup yarn
         if: inputs.package_manager == 'yarn'
         run: yarn install --frozen-lockfile

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -49,7 +49,8 @@ jobs:
           npm i -g json
           echo "PACKAGE_VERSION=${{json -f package.json | json version}}" >> $GITHUB_ENV
           json -I -f package.json -e "this.version=\"{{env.}}-beta.${{github.event.number}}}\""
-
+        shell: run
+        
       - name: Setup yarn
         if: inputs.package_manager == 'yarn'
         run: yarn install --frozen-lockfile

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -47,10 +47,10 @@ jobs:
         if: inputs.tag == 'beta'
         run: |
           npm i -g json
-          echo PACKAGE_VERSION=${{json -f package.json | json version}} >> $GITHUB_ENV
+          echo "PACKAGE_VERSION=${{json -f package.json | json version}}" >> $GITHUB_ENV
           json -I -f package.json -e "this.version=\"{{env.}}-beta.${{github.event.number}}}\""
         shell: run
-
+        
       - name: Setup yarn
         if: inputs.package_manager == 'yarn'
         run: yarn install --frozen-lockfile

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -44,23 +44,17 @@ jobs:
         node-version: latest
         cache: {{ inputs.package_manager }}
     
-    - name: install jq
-      run: apt-get install jq
-
-    - name: check if beta and update package.json
+    - name: install json if beta
       if: inputs.tag == 'beta'
-      uses: sergeysova/jq-action@v2
-      id: version
-      with:
-        cmd: 'jq .version package.json -r'
-
-      #run: echo "VERSION=${{jq -r .version package.json}} >> $GITHUB_ENV
-    
-    - name: set package.json for beta
+      run: npm i -g -y json
+     
+     - name: version value from package.json
       if: inputs.tag == 'beta'
-      uses: sergeysova/jq-action@v2
-      with:
-        cmd: 'echo "`jq '.version="${{steps.version.outputs.value}}-beta.${{github.event.number}}"' package.json`" > package.json'
+      run: echo "PACKAGE_VERSION=${{json -f package.json | json version}}" >> $GITHUB_ENV
+
+    - name: beta - update package.json
+      if: inputs.tag == 'beta'
+      run: json -I -f package.json -e "this.version=\"{{env.}}-beta.${{github.event.number}}}\""
       #run: echo "`jq '.version="${{env.VERSION}}-beta.${{github.event.number}}"' package.json`" > package.json
 
     - name: Setup yarn

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -42,15 +42,11 @@ jobs:
           always-auth: true
           node-version: latest
           cache: {{ inputs.package_manager }}
-            
+
       - name: beta - version value from package.json
         if: inputs.tag == 'beta'
-        run: |
-          npm i -g json
-          echo "PACKAGE_VERSION=${{json -f package.json | json version}}" >> $GITHUB_ENV
-          json -I -f package.json -e "this.version=\"{{env.PACKAGE_VERSION}}-beta.${{github.event.number}}}\""
-        shell: run
-        
+        run: npm i -g json
+
       - name: Setup yarn
         if: inputs.package_manager == 'yarn'
         run: yarn install --frozen-lockfile

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -9,7 +9,7 @@ on:
       build_artifact:
         required: false
         type: string
-        default: build
+        default: dist
       package_manager:
         required: false
         type: string

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -41,7 +41,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           always-auth: true
           node-version: latest
-          cache: {{ inputs.package_manager }}
+          cache: ${{ inputs.package_manager }}
 
       - name: beta - version value from package.json
         if: inputs.tag == 'beta'

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -48,7 +48,12 @@ jobs:
         run: npm i -g json
       
       - name: set package version
+        if: inputs.tag == 'beta'
         run: echo "PACKAGE_VERSION=${{json -f package.json | json version}}" >> $GITHUB_ENV
+
+      - name: run package.json update for beta
+        if: inputs.tag == 'beta'
+        run: json -I -f package.json -e "this.version=\"{{env.PACKAGE_VERSION}}-beta.${{github.event.number}}}\""
 
       - name: Setup yarn
         if: inputs.package_manager == 'yarn'

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -26,49 +26,48 @@ env:
   NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
 jobs:
-  npm:
-    name: Publish to npm
-    runs-on: ubuntu-latest
-    steps:
-        
-    - name: Retrieve build artifacts
-      uses: actions/download-artifact@v3
-      with:
-        name: ${{ inputs.build_artifact }}
+  npmjs:
+      name: Publish to npm
+      runs-on: ubuntu-latest
+      steps: 
+      - name: Retrieve build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.build_artifact }}
 
-    - name: Setup node with cache
-      uses: actions/setup-node@v3
-      with:
-        registry-url: 'https://registry.npmjs.org'
-        always-auth: true
-        node-version: latest
-        cache: {{ inputs.package_manager }}
-    
-    - name: install json if beta
-      if: inputs.tag == 'beta'
-      run: npm i -g -y json
-     
-     - name: version value from package.json
-      if: inputs.tag == 'beta'
-      run: echo "PACKAGE_VERSION=${{json -f package.json | json version}}" >> $GITHUB_ENV
+      - name: Setup node with cache
+        uses: actions/setup-node@v3
+        with:
+          registry-url: 'https://registry.npmjs.org'
+          always-auth: true
+          node-version: latest
+          cache: {{ inputs.package_manager }}
+      
+      - name: install json if beta
+        if: inputs.tag == 'beta'
+        run: npm i -g -y json
+      
+      - name: version value from package.json
+        if: inputs.tag == 'beta'
+        run: echo "PACKAGE_VERSION=${{json -f package.json | json version}}" >> $GITHUB_ENV
 
-    - name: beta - update package.json
-      if: inputs.tag == 'beta'
-      run: json -I -f package.json -e "this.version=\"{{env.}}-beta.${{github.event.number}}}\""
-      #run: echo "`jq '.version="${{env.VERSION}}-beta.${{github.event.number}}"' package.json`" > package.json
+      - name: beta - update package.json
+        if: inputs.tag == 'beta'
+        run: json -I -f package.json -e "this.version=\"{{env.}}-beta.${{github.event.number}}}\""
+        #run: echo "`jq '.version="${{env.VERSION}}-beta.${{github.event.number}}"' package.json`" > package.json
 
-    - name: Setup yarn
-      if: inputs.package_manager == 'yarn'
-      run: yarn install --frozen-lockfile
+      - name: Setup yarn
+        if: inputs.package_manager == 'yarn'
+        run: yarn install --frozen-lockfile
 
-    - name: Publish with yarn command
-      if: inputs.package_manager == 'yarn'
-      run: yarn publish --access ${{ inputs.package_visibility }} --tag ${{ inputs.tag }}
+      - name: Publish with yarn command
+        if: inputs.package_manager == 'yarn'
+        run: yarn publish --access ${{ inputs.package_visibility }} --tag ${{ inputs.tag }}
 
-    - name: Setup npm
-      if: inputs.package_manager == 'npm'
-      run: npm ci
+      - name: Setup npm
+        if: inputs.package_manager == 'npm'
+        run: npm ci
 
-    - name: Publish with npm command
-      if: inputs.package_manager == 'npm'
-      run: npm publish --access ${{ inputs.package_visibility }} --tag ${{ inputs.tag }}
+      - name: Publish with npm command
+        if: inputs.package_manager == 'npm'
+        run: npm publish --access ${{ inputs.package_visibility }} --tag ${{ inputs.tag }}

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           npm i -g json
           echo "PACKAGE_VERSION=${{json -f package.json | json version}}" >> $GITHUB_ENV
-          json -I -f package.json -e "this.version=\"{{env.}}-beta.${{github.event.number}}}\""
+          json -I -f package.json -e "this.version=\"{{env.PACKAGE_VERSION}}-beta.${{github.event.number}}}\""
         shell: run
         
       - name: Setup yarn

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -43,15 +43,17 @@ jobs:
         always-auth: true
         node-version: latest
         cache: {{ inputs.package_manager }}
+    
+    - name: install jq
+      run: apt-get install jq
 
     - name: check if beta and update package.json
       if: inputs.tag == 'beta'
       run: echo "VERSION=${{jq -r .version package.json}} >> $GITHUB_ENV
-
+    
     - name: set package.json for beta
       if: inputs.tag == 'beta'
       run: echo "`jq '.version="${{env.VERSION}}-beta.${{github.event.number}}"' package.json`" > package.json
-
 
     - name: Setup yarn
       if: inputs.package_manager == 'yarn'

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -49,11 +49,19 @@ jobs:
 
     - name: check if beta and update package.json
       if: inputs.tag == 'beta'
-      run: echo "VERSION=${{jq -r .version package.json}} >> $GITHUB_ENV
+      uses: sergeysova/jq-action@v2
+      id: version
+      with:
+        cmd: 'jq .version package.json -r'
+
+      #run: echo "VERSION=${{jq -r .version package.json}} >> $GITHUB_ENV
     
     - name: set package.json for beta
       if: inputs.tag == 'beta'
-      run: echo "`jq '.version="${{env.VERSION}}-beta.${{github.event.number}}"' package.json`" > package.json
+      uses: sergeysova/jq-action@v2
+      with:
+        cmd: 'echo "`jq '.version="${{steps.version.outputs.value}}-beta.${{github.event.number}}"' package.json`" > package.json'
+      #run: echo "`jq '.version="${{env.VERSION}}-beta.${{github.event.number}}"' package.json`" > package.json
 
     - name: Setup yarn
       if: inputs.package_manager == 'yarn'

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -6,6 +6,18 @@ on:
         required: false
         type: string
         default: latest
+      build_artifact:
+        required: false
+        type: string
+        default: build
+      package_manager:
+        required: false
+        type: string
+        default: yarn
+      package_visibility:
+        required: false
+        type: string
+        default: public
     secrets:
       NODE_AUTH_TOKEN:
         required: true
@@ -22,9 +34,10 @@ jobs:
     - name: Retrieve build artifacts
       uses: actions/download-artifact@v3
       with:
-        name: dist
+        name: ${{ inputs.build_artifact }}
 
-    - name: Setup node
+    - name: Setup node with yarn cache
+      if: inputs.package_manager == 'yarn'
       uses: actions/setup-node@v3
       with:
         registry-url: 'https://registry.npmjs.org'
@@ -33,7 +46,17 @@ jobs:
         cache: 'yarn'
 
     - name: Setup yarn
+      if: inputs.package_manager == 'yarn'
       run: yarn install --frozen-lockfile
 
-    - name: Publish
-      run: yarn publish --access public --tag ${{ inputs.tag }}
+    - name: Publish with yarn command
+      if: inputs.package_manager == 'yarn'
+      run: yarn publish --access ${{ inputs.package_visibility }} --tag ${{ inputs.tag }}
+
+    - name: Setup npm
+      if: inputs.package_manager == 'npm'
+      run: npm ci
+
+    - name: Publish with npm command
+      if: inputs.package_manager == 'npm'
+      run: npm publish --access ${{ inputs.package_visibility }} --tag ${{ inputs.tag }}

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -45,7 +45,11 @@ jobs:
 
       - name: beta - version value from package.json
         if: inputs.tag == 'beta'
-        run: npm i -g json && echo "PACKAGE_VERSION=${{npx json -f package.json | json version}}" >> $GITHUB_ENV
+        run: npm i -g json 
+        
+      - name: beta - version value from package.json
+        if: inputs.tag == 'beta'
+        run: echo "PACKAGE_VERSION=${{ npx json -f package.json | json version }}" >> $GITHUB_ENV
 
       - name: Setup yarn
         if: inputs.package_manager == 'yarn'

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -36,14 +36,22 @@ jobs:
       with:
         name: ${{ inputs.build_artifact }}
 
-    - name: Setup node with yarn cache
-      if: inputs.package_manager == 'yarn'
+    - name: Setup node with cache
       uses: actions/setup-node@v3
       with:
         registry-url: 'https://registry.npmjs.org'
         always-auth: true
         node-version: latest
-        cache: 'yarn'
+        cache: {{ inputs.package_manager }}
+
+    - name: check if beta and update package.json
+      if: inputs.tag == 'beta'
+      run: echo "VERSION=${{jq -r .version package.json}} >> $GITHUB_ENV
+
+    - name: set package.json for beta
+      if: inputs.tag == 'beta'
+      run: echo "`jq '.version="${{env.VERSION}}-beta.${{github.event.number}}"' package.json`" > package.json
+
 
     - name: Setup yarn
       if: inputs.package_manager == 'yarn'

--- a/.github/workflows/typescript.publish.npm.yml
+++ b/.github/workflows/typescript.publish.npm.yml
@@ -46,7 +46,7 @@ jobs:
       - name: beta - version value from package.json
         if: inputs.tag == 'beta'
         run: |
-          npm i -g -y json
+          npm i -g json
           echo "PACKAGE_VERSION=${{json -f package.json | json version}}" >> $GITHUB_ENV
           json -I -f package.json -e "this.version=\"{{env.}}-beta.${{github.event.number}}}\""
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ Pushes node package to [npm](https://www.npmjs.com/) under the `@flexbase` scope
     secrets: inherit
 ```
 
+publishing to production: 
+```
+  publish:
+    needs: coverage
+    uses: flexbase-eng/.github/.github/workflows/typescript.publish.yml@main
+    secrets: inherit
+```
+
 #### Inputs
 
 Input | Type | Default | Required

--- a/README.md
+++ b/README.md
@@ -94,7 +94,10 @@ Pushes node package to [npm](https://www.npmjs.com/) under the `@flexbase` scope
 
 Input | Type | Default | Required
 --- | --- | --- | ---
-tag | `string` | latest | 
+tag | `string` | latest | no
+build_artifact | `string` | latest | no
+package_manager | `string` | yarn | no
+package_visibility | `string` | public | no
 
 #### Steps
 


### PR DESCRIPTION
- added check for yarn lock in build shared workflow, to adapt to both package manager systems
- add option in publish step to publish with npm
- add option to utilize public or private publish methods