### PR TITLE
Test/release notifier

### DIFF
--- a/.github/workflows/release.notifier.tag.yml
+++ b/.github/workflows/release.notifier.tag.yml
@@ -1,0 +1,87 @@
+# fun notes around commit messages
+# https://github.com/slackapi/slack-github-action/issues/116
+name: Production Release Slack Notification
+on:
+  workflow_call:
+    inputs:
+      gha_deployment_failure_url:
+        required: false
+        type: string
+        default: ''
+      production_url:
+        required: false
+        type: string
+        default: 'https://flexbase.app'
+      release_title:
+        required: false
+        type: string
+        default: 'flexbase application'
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  FAILURE_URL: ${{ inputs.gha_deployment_failure_url }}
+  PRODUCTION_URL: ${{ inputs.production_url }}
+  RELEASE_TITLE: ${{ inputs.release_title || github.event.repository.name }}
+
+permissions:
+  contents: read
+
+jobs:
+  prod-notify-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Latest Release List
+        uses: octokit/request-action@v2.x
+        id: get_latest_release
+        with:
+          route: GET /repos/{owner}/{repo}/releases/latest
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }} 
+      
+      - name: Prepare Release Info
+        id: slack-prepare
+        run: |
+          RELEASE_MESSAGE="${{ fromJSON(steps.get_latest_release.outputs.data).body }}"
+          RELEASE_MESSAGE="$(echo ${RELEASE_MESSAGE:0:2800})"
+          RELEASE_MESSAGE="$(echo $RELEASE_MESSAGE | sed -z 's/\n/\\n/g; s/"//g;')"
+          echo "release-message=$RELEASE_MESSAGE" >> $GITHUB_OUTPUT
+      - name: Post Success to a Slack channel
+        id: slack-success
+        uses: slackapi/slack-github-action@v1.19.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Mobile App release ${{ fromJSON(steps.get_latest_release.outputs.data).tag_name }} has been submitted for app review. :rocket:"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Github Release Page*: <${{ fromJSON(steps.get_latest_release.outputs.data).html_url }}|${{ fromJSON(steps.get_latest_release.outputs.data).tag_name }}>"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ${{ toJSON(steps.slack-prepare.outputs.release-message) }}
+                  }
+                },
+                {
+                  "type": "divider"
+                }
+              ]
+            }
+
+      

--- a/.github/workflows/release.notifier.yml
+++ b/.github/workflows/release.notifier.yml
@@ -31,10 +31,10 @@ permissions:
 jobs:
   prod-notify:
     runs-on: ubuntu-latest
-    if: github.event_name != 'release'
     steps:
       - name: Get commits
         uses: octokit/request-action@v2.x
+        if: github.event_name != 'release'
         id: get_commit_list
         with:
           route: GET /repos/{owner}/{repo}/commits?sha=${{ github.sha }}
@@ -43,6 +43,7 @@ jobs:
       
       - name: Prepare
         id: slack-prepare
+        if: github.event_name != 'release'
         run: |
           COMMIT_MESSAGE="${{ fromJSON(steps.get_commit_list.outputs.data)[0].commit.message }}"
           COMMIT_MESSAGE="$(echo ${COMMIT_MESSAGE:0:2800})"
@@ -50,8 +51,8 @@ jobs:
           echo "commit-message=$COMMIT_MESSAGE" >> $GITHUB_OUTPUT
 
       - name: Post Success to a Slack channel
-        if: ${{ success() }}
         id: slack-success
+        if: github.event_name != 'release'
         uses: slackapi/slack-github-action@v1.19.0
         with:
           payload: |
@@ -93,13 +94,9 @@ jobs:
                 }
               ]
             }
-
-  prod-notify-tag:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release'
-    steps:
+      
       - name: Get Latest Release List
-        if: ${{ success() }}
+        if: github.event_name == 'release'
         uses: octokit/request-action@v2.x
         id: get_latest_release
         with:
@@ -109,6 +106,7 @@ jobs:
       
       - name: Prepare Release Info
         id: slack-prepare
+        if: github.event_name == 'release'
         run: |
           RELEASE_MESSAGE="${{ fromJSON(steps.get_latest_release.outputs.data).body }}"
           RELEASE_MESSAGE="$(echo ${RELEASE_MESSAGE:0:2800})"
@@ -116,7 +114,7 @@ jobs:
           echo "release-message=$RELEASE_MESSAGE" >> $GITHUB_OUTPUT
 
       - name: Post Success to a Slack channel
-        if: ${{ success() }}
+        if: github.event_name == 'release'
         id: slack-success
         uses: slackapi/slack-github-action@v1.19.0
         with:
@@ -152,3 +150,4 @@ jobs:
                 }
               ]
             }
+      

--- a/.github/workflows/release.notifier.yml
+++ b/.github/workflows/release.notifier.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   prod-notify:
     runs-on: ubuntu-latest
-    if: github.event_name != release
+    if: github.event_name != 'release'
     steps:
       - name: Get commits
         uses: octokit/request-action@v2.x
@@ -96,7 +96,7 @@ jobs:
 
   prod-notify-tag:
     runs-on: ubuntu-latest
-    if: github.event_name == release
+    if: github.event_name == 'release'
     steps:
       - name: Get Latest Release List
         if: ${{ success() }}

--- a/.github/workflows/release.notifier.yml
+++ b/.github/workflows/release.notifier.yml
@@ -34,6 +34,7 @@ jobs:
     steps:
       - name: Get commits
         uses: octokit/request-action@v2.x
+        if: github.event_name != 'release'
         id: get_commit_list
         with:
           route: GET /repos/{owner}/{repo}/commits?sha=${{ github.sha }}
@@ -42,6 +43,7 @@ jobs:
       
       - name: Prepare
         id: slack-prepare
+        if: github.event_name != 'release'
         run: |
           COMMIT_MESSAGE="${{ fromJSON(steps.get_commit_list.outputs.data)[0].commit.message }}"
           COMMIT_MESSAGE="$(echo ${COMMIT_MESSAGE:0:2800})"
@@ -148,4 +150,5 @@ jobs:
                 }
               ]
             }
+
       

--- a/.github/workflows/release.notifier.yml
+++ b/.github/workflows/release.notifier.yml
@@ -34,7 +34,6 @@ jobs:
     steps:
       - name: Get commits
         uses: octokit/request-action@v2.x
-        if: github.event_name != 'release'
         id: get_commit_list
         with:
           route: GET /repos/{owner}/{repo}/commits?sha=${{ github.sha }}
@@ -43,7 +42,6 @@ jobs:
       
       - name: Prepare
         id: slack-prepare
-        if: github.event_name != 'release'
         run: |
           COMMIT_MESSAGE="${{ fromJSON(steps.get_commit_list.outputs.data)[0].commit.message }}"
           COMMIT_MESSAGE="$(echo ${COMMIT_MESSAGE:0:2800})"
@@ -52,7 +50,6 @@ jobs:
 
       - name: Post Success to a Slack channel
         id: slack-success
-        if: github.event_name != 'release'
         uses: slackapi/slack-github-action@v1.19.0
         with:
           payload: |
@@ -87,62 +84,6 @@ jobs:
                   "text": {
                     "type": "mrkdwn",
                     "text": "*Commit Details*: ${{ fromJSON(steps.get_commit_list.outputs.data)[0].html_url }}"
-                  }
-                },
-                {
-                  "type": "divider"
-                }
-              ]
-            }
-      
-      - name: Get Latest Release List
-        if: github.event_name == 'release'
-        uses: octokit/request-action@v2.x
-        id: get_latest_release
-        with:
-          route: GET /repos/{owner}/{repo}/releases/latest
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.event.repository.name }} 
-      
-      - name: Prepare Release Info
-        id: slack-prepare
-        if: github.event_name == 'release'
-        run: |
-          RELEASE_MESSAGE="${{ fromJSON(steps.get_latest_release.outputs.data).body }}"
-          RELEASE_MESSAGE="$(echo ${RELEASE_MESSAGE:0:2800})"
-          RELEASE_MESSAGE="$(echo $RELEASE_MESSAGE | sed -z 's/\n/\\n/g; s/"//g;')"
-          echo "release-message=$RELEASE_MESSAGE" >> $GITHUB_OUTPUT
-
-      - name: Post Success to a Slack channel
-        if: github.event_name == 'release'
-        id: slack-success
-        uses: slackapi/slack-github-action@v1.19.0
-        with:
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "Mobile App release ${{ fromJSON(steps.get_latest_release.outputs.data).tag_name }} has been submitted for app review. :rocket:"
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Github Release Page*: <${{ fromJSON(steps.get_latest_release.outputs.data).html_url }}|${{ fromJSON(steps.get_latest_release.outputs.data).tag_name }}>"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ${{ toJSON(steps.slack-prepare.outputs.release-message) }}
                   }
                 },
                 {

--- a/.github/workflows/release.notifier.yml
+++ b/.github/workflows/release.notifier.yml
@@ -34,7 +34,6 @@ jobs:
     steps:
       - name: Get commits
         uses: octokit/request-action@v2.x
-        if: github.event_name != 'release'
         id: get_commit_list
         with:
           route: GET /repos/{owner}/{repo}/commits?sha=${{ github.sha }}
@@ -43,7 +42,6 @@ jobs:
       
       - name: Prepare
         id: slack-prepare
-        if: github.event_name != 'release'
         run: |
           COMMIT_MESSAGE="${{ fromJSON(steps.get_commit_list.outputs.data)[0].commit.message }}"
           COMMIT_MESSAGE="$(echo ${COMMIT_MESSAGE:0:2800})"

--- a/.github/workflows/test.release.notifier.yml
+++ b/.github/workflows/test.release.notifier.yml
@@ -8,7 +8,6 @@ env:
   SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 jobs:
   notify-prod:
-    needs: deploy-prod
     uses: flexbase-eng/.github/.github/workflows/release.notifier.yml@test/release-notifier
     with:
       gha_deployment_failure_url: https://github.com/flexbase-eng/flexbase-web/actions/workflows/deploy-prod.yml

--- a/.github/workflows/test.release.notifier.yml
+++ b/.github/workflows/test.release.notifier.yml
@@ -2,7 +2,7 @@ name: 'Test the release notification'
 on:
   push:
     branches:
-      - test/release-notifier
+      - main
 env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/test.release.notifier.yml
+++ b/.github/workflows/test.release.notifier.yml
@@ -1,0 +1,16 @@
+name: 'Test the release notification'
+on:
+  push:
+    branches:
+      - test/release-notifier
+env:
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+jobs:
+  notify-prod:
+    needs: deploy-prod
+    uses: flexbase-eng/.github/.github/workflows/release.notifier.yml@test/release-notifier
+    with:
+      gha_deployment_failure_url: https://github.com/flexbase-eng/flexbase-web/actions/workflows/deploy-prod.yml
+      release_title: Flexbase Test Notification
+    secrets: inherit


### PR DESCRIPTION
- create a test for the notifier and break out tag notifications since shared workflows require at least 1 job that has no dependencies