### PR TITLE
additional option for release notification and addition of shared workflow to persist internal github repos

### DIFF
--- a/.github/workflows/deploy.gcr.yml
+++ b/.github/workflows/deploy.gcr.yml
@@ -8,6 +8,10 @@ on:
       project_id:
         required: true
         type: string
+      labels:
+        type: string
+        required: false
+        description: "labels to add to service such as service=banking"
 
 env:
   SERVICE_NAME: ${{ inputs.service_name }}
@@ -24,7 +28,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
+
     # Google Cloud: Configure Workload Identity Federation and generate an access token.
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
@@ -32,16 +37,19 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SA_EMAIL }}
+
       # Setup gcloud CLI
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
       - run: echo "$PROJECT_ID/$SERVICE_NAME:$GITHUB_SHA"
+
       # Build and push image to Google Container Registry
       - name: Build and Push Container
         run: |-
           gcloud builds submit \
             --tag "gcr.io/$PROJECT_ID/$SERVICE_NAME:$GITHUB_SHA" \
             --gcs-log-dir gs://artifacts.flexbase-api-development.appspot.com
+      
       # deploy latest container      
       - id: 'deploy'
         uses: 'google-github-actions/deploy-cloudrun@v0'

--- a/.github/workflows/github.package.internal.json
+++ b/.github/workflows/github.package.internal.json
@@ -1,0 +1,11 @@
+{
+    "name": "Setup Internal GHA Repos",
+    "description": "internal package setup",
+    "iconName": "github.package.internal",
+    "categories": [
+        "packages", "gha"
+    ],
+    "filePatterns": [
+        "package.json$"
+    ]
+}

--- a/.github/workflows/github.package.internal.svg
+++ b/.github/workflows/github.package.internal.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M5 4v2h14V4H5zm0 10h4v6h6v-6h4l-7-7-7 7z"/></svg>

--- a/.github/workflows/github.package.internal.yml
+++ b/.github/workflows/github.package.internal.yml
@@ -1,0 +1,19 @@
+name: Set up Flexbase Github Internal Packages
+on:
+  workflow_call:
+
+env:
+  PACKAGE_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
+
+jobs:
+  set-internal-packages:
+    runs-on: ubuntu-latest
+    steps:
+      # pull down compiled build artifact to build_artifact_download_path locally
+      - name: set up flexbase internal packages
+        env: 
+          PACKAGE_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=$PACKAGE_TOKEN" > .npmrc
+          echo "@flexbase-eng:registry=https://npm.pkg.github.com" >> .npmrc
+          echo "always-auth=true" >> .npmrc

--- a/.github/workflows/release.notifier.yml
+++ b/.github/workflows/release.notifier.yml
@@ -20,10 +20,6 @@ on:
         required: false
         type: string
         default: 'production'
-      release_type: 
-        required: false
-        type: string
-        default: 'commit'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.notifier.yml
+++ b/.github/workflows/release.notifier.yml
@@ -16,6 +16,14 @@ on:
         required: false
         type: string
         default: 'flexbase application'
+      release_env: 
+        required: false
+        type: string
+        default: 'production'
+      release_type: 
+        required: false
+        type: string
+        default: 'commit'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -24,6 +32,7 @@ env:
   FAILURE_URL: ${{ inputs.gha_deployment_failure_url }}
   PRODUCTION_URL: ${{ inputs.production_url }}
   RELEASE_TITLE: ${{ inputs.release_title || github.event.repository.name }}
+  RELEASE_ENV: ${{ inputs.release_env }}
 
 permissions:
   contents: read
@@ -59,7 +68,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": ":rocket: ${{ env.RELEASE_TITLE }} has been shipped to production. :rocket:"
+                    "text": ":rocket: ${{ env.RELEASE_TITLE }} has been shipped to ${{ env.RELEASE_ENV }}. :rocket:"
                   }
                 },
                 {


### PR DESCRIPTION
- main item is the release notification addition needed so i can alert on when demo env deploys
- extra work that was in flight was a way to pull in and generate the internal github repo references as a shared step/workflow, and reduce away the needed implementation details to pull private repos.