### PR TITLE
Feature/fbt 1975 add gcp emulators to unit test scripts in GitHub workflows

### DIFF
--- a/.github/workflows/test.unit.typescript.yml
+++ b/.github/workflows/test.unit.typescript.yml
@@ -52,6 +52,14 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      gcp:
+        image: google/cloud-sdk:439.0.0
+        ports:
+            - 8085:8085
+        expose:
+            - 8085
+        command: >
+            bash -c "gcloud beta emulators pubsub start --host-port=0.0.0.0:8085"
 
     steps:
       - name: Create environment variables for npm commands

--- a/.github/workflows/test.unit.typescript.yml
+++ b/.github/workflows/test.unit.typescript.yml
@@ -25,6 +25,10 @@ on:
         required: false
         type: boolean
         default: false
+      use_gcp_emulators:
+        required: false
+        type: boolean
+        default: false
       build_cache_key:
         required: false
         type: string
@@ -81,12 +85,14 @@ jobs:
           which migrate
 
       - name: 'Install Cloud SDK'
+        if: ${{ inputs.use_gcp_emulators == true }}
         uses: google-github-actions/setup-gcloud@v1
         with:
           version: '>= 439.0.0'
           install_components: 'beta,pubsub-emulator'
 
       - name: 'Start Pub/Sub emulator'
+        if: ${{ inputs.use_gcp_emulators == true }}
         run: |
           gcloud beta emulators pubsub start --host-port=0.0.0.0:8085 &
 

--- a/.github/workflows/test.unit.typescript.yml
+++ b/.github/workflows/test.unit.typescript.yml
@@ -52,14 +52,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-      gcp:
-        image: google/cloud-sdk:439.0.0
-        ports:
-            - 8085:8085
-        expose:
-            - 8085
-        command: >
-            bash -c "gcloud beta emulators pubsub start --host-port=0.0.0.0:8085"
 
     steps:
       - name: Create environment variables for npm commands
@@ -88,7 +80,19 @@ jobs:
           sudo mv migrate /usr/bin/
           which migrate
 
+      - name: 'Install Cloud SDK'
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          version: '>= 439.0.0'
+          install_components: 'beta,pubsub-emulator'
+
+      - name: 'Start Pub/Sub emulator'
+        run: |
+          gcloud beta emulators pubsub start --host-port=0.0.0.0:8085 &
+
       - name: Run tests
+        env:
+          PUBSUB_EMULATOR_HOST: 'localhost:8085'
         run: ${{ env.CLI_TEST }}
 
       - name: Upload coverage artifacts


### PR DESCRIPTION
Unfortunately service containers do now allow you to override ENTRYPOINT or CMD
- https://github.com/orgs/community/discussions/52675

so I'm setting it up in the run steps here and using the `install_components` param to get the emulators imported
- https://github.com/google-github-actions/setup-gcloud#cloud-sdk-inputs

Not sure how to test this, open to feedback.