### PR TITLE
[chore] bump gha versions for workflows

### DIFF
--- a/.github/workflows/build.typescript.highmem.yml
+++ b/.github/workflows/build.typescript.highmem.yml
@@ -102,7 +102,7 @@ jobs:
         id: dependencies-cache
         env:
           FILE_HASH: ${{ hashFiles(env.LOCK_FILE) }}
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ./node_modules
           key: node-modules-${{ runner.os }}-${{ env.FILE_HASH }}

--- a/.github/workflows/build.typescript.yml
+++ b/.github/workflows/build.typescript.yml
@@ -101,7 +101,7 @@ jobs:
         id: dependencies-cache
         env:
           FILE_HASH: ${{ hashFiles(env.LOCK_FILE) }}
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ./node_modules
           key: node-modules-${{ runner.os }}-${{ env.FILE_HASH }}

--- a/.github/workflows/coverage.sonarcloud.yml
+++ b/.github/workflows/coverage.sonarcloud.yml
@@ -49,7 +49,7 @@ jobs:
           persist-credentials: false
 
       - name: Retrieve coverage artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.coverage_artifact_name }}
           path: ${{ inputs.coverage_artifact_folder }}

--- a/.github/workflows/deploy.chromatic.yml
+++ b/.github/workflows/deploy.chromatic.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Retrieve build cache
         id: cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ./*
           key: build-cache-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/deploy.netlify.yml
+++ b/.github/workflows/deploy.netlify.yml
@@ -51,7 +51,7 @@ jobs:
         run: echo "NETLIFY_PROD=--prod" >> $GITHUB_ENV
 
       - name: Retrieve build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.build_artifact_name }}
           path: ${{ inputs.build_artifact_folder }}

--- a/.github/workflows/deploy.npm.yml
+++ b/.github/workflows/deploy.npm.yml
@@ -51,7 +51,7 @@ jobs:
         run: echo "CLI_PUBLISH=npm publish --access ${{ inputs.package_visibility }} --tag ${{ inputs.tag }}" >> $GITHUB_ENV
 
       - name: Retrieve build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.build_artifact_name }}
           path: ${{ inputs.build_artifact_folder }}

--- a/.github/workflows/deploy.web.netlify.yml
+++ b/.github/workflows/deploy.web.netlify.yml
@@ -31,7 +31,7 @@ jobs:
         run: echo "NETLIFY_PROD=--prod" >> $GITHUB_ENV
 
       - name: Retrieve build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.build_artifact_download }}
           path: ${{ inputs.build_artifact_download_path }}

--- a/.github/workflows/package.typescript.yml
+++ b/.github/workflows/package.typescript.yml
@@ -74,14 +74,14 @@ jobs:
           echo "CLI_PACKR=npm run ${{ inputs.packr_command }}" >> $GITHUB_ENV
 
       - name: Retrieve build cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ./*
           key: ${{ inputs.build_cache_key }}
           fail-on-cache-miss: true
 
       - name: Setup Node ${{ inputs.node_version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload build artifacts
         if: ${{ inputs.build_artifact_folder != ''}}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.build_artifact_name }}
           path: ${{ inputs.build_artifact_folder }}

--- a/.github/workflows/test.component.typescript.yml
+++ b/.github/workflows/test.component.typescript.yml
@@ -38,14 +38,14 @@ jobs:
         run: echo "CLI_TEST=npm run ${{ inputs.test_command }}" >> $GITHUB_ENV
 
       - name: Retrieve build cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ./*
           key: build-cache-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           fail-on-cache-miss: true
 
       - name: Retrieve cypress binary cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ${{ inputs.cypress_bin_path }}
           key: cypress-${{ runner.os }}

--- a/.github/workflows/test.e2e.typescript.yml
+++ b/.github/workflows/test.e2e.typescript.yml
@@ -51,14 +51,14 @@ jobs:
         run: echo "CLI_TEST=npm run ${{ inputs.test_command }}" >> $GITHUB_ENV
 
       - name: Retrieve build cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ./*
           key: ${{ inputs.build_cache_key }}
           fail-on-cache-miss: true
 
       - name: Retrieve cypress binary cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ${{ inputs.cypress_bin_path }}
           key: cypress-${{ runner.os }}
@@ -68,7 +68,7 @@ jobs:
         run: ${{ env.CLI_TEST }} --ci-build-id ${{ env.CURRENTS_BUILD_ID }} --config baseUrl=${{ env.BASE_URL }}
         timeout-minutes: 5
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots

--- a/.github/workflows/test.unit.typescript.yml
+++ b/.github/workflows/test.unit.typescript.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Retrieve build cache
         id: cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ./*
           key: ${{ inputs.build_cache_key }}
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload coverage artifacts
         if: ${{ inputs.coverage_artifact_folder != ''}}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.coverage_artifact_name }}
           path: ${{ inputs.coverage_artifact_folder }}

--- a/.github/workflows/typescript.sonarcloud.yml
+++ b/.github/workflows/typescript.sonarcloud.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Retrieve coverage artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: code-coverage-report
           path: coverage


### PR DESCRIPTION
need to make changes to the other repos, testing in Platform v3 and v4 are not compatible

----

[download](https://github.com/actions/download-artifact/tree/v4.1.3) and [upload](https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new) v4 notes state there should be a "significant performance boost"

prod packaging takes almost 5 minutes on Platform so hoping this helps a bit 🙏 

