### PR TITLE
Use explicit sonarcloud version

### DIFF
--- a/.github/workflows/typescript.sonarcloud.yml
+++ b/.github/workflows/typescript.sonarcloud.yml
@@ -31,7 +31,7 @@ jobs:
           path: coverage
 
       - name: SonarQube Scan
-        uses: sonarsource/sonarqube-scan-action@latest
+        uses: sonarsource/sonarqube-scan-action@v5
         with:
           args: >
             -Dsonar.organization=${{ env.SONAR_ORG }}


### PR DESCRIPTION
Use v5 explicitly

Can see it running in Platform here:
https://github.com/flexbase-eng/platform/actions/runs/13394759990/job/37411434611